### PR TITLE
efetch needs either ids or webenv

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -96,7 +96,7 @@ function validateOptionsExist(options) {
 
 function validateIds(options) {
 	validateOptionsExist(options)
-	if (!options.id && !options.ids) throw new Error('Must provide options.ids')
+	if ((!options.id && !options.ids) && (!options.query_key && !options.WebEnv)) throw new Error('Must provide options.ids or options.WebEnv');
 }
 
 function validateDbFrom(options) {


### PR DESCRIPTION
According to the [documentation](https://www.ncbi.nlm.nih.gov/books/NBK25499/#chapter4.EFetch) eFetch needs either an ID or a WebEnv (when using a history server)
This PR adds that to the id check